### PR TITLE
createRoom의 max_meeting_time 수정

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -733,10 +733,10 @@ components:
           type: boolean
           description: All meeting will be recorded
           default: true
-        max_meeting_time:
+        max_meeting_seconds:
           type: integer
           description:
-            Determines the maximum meeting duration. Once this time has elapsed, the meeting room will be automatically terminated.
+            Determines the maximum meeting time in seconds. Once this time has elapsed, the meeting room will be automatically terminated.
             The 'meeting time' refers to the duration during which two or more participants are connected. If a `max_meeting_time` is set, the timer UI will display the remaining meeting time, rather than the elapsed time.
         members:
           type: array


### PR DESCRIPTION
https://github.com/pplink/pagecall/pull/3238로 인해 docs를 수정합니다.

기존 createRoom의 body에 max_meeting_times라고 잘못 표기되어 있는 것을 max_meeting_seconds로 바꾸고 설명에 단위를 명시하였습니다.