### PR TITLE
include notice on URL encoding requirements

### DIFF
--- a/references/endpoints/Create_Room_Pages.mdx
+++ b/references/endpoints/Create_Room_Pages.mdx
@@ -28,3 +28,7 @@ Currently, You cannot try this API on the docs.
 ```
 
 This will create two pages, each containing a picture of a dog and a fox respectively.
+
+### URL Encoding Requirement
+
+> **Notice**: Always encode URLs when using Pagecall's APIs. Unencoded URLs may lead to errors, for which Pagecall is not liable.


### PR DESCRIPTION
URL 인코딩하지 않을시 자비는 없다는 것을 천명합니다.

<img width="718" alt="image" src="https://github.com/pplink/pagecall-docs/assets/19991994/ada4443e-9572-4b36-bb06-c6e945690678">
