### PR TITLE
Add support of is_terminated for List Rooms

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -43,6 +43,11 @@ paths:
           schema:
             type: string
           description: Layout name to search.
+        - in: query
+          name: is_terminated
+          schema:
+            type: boolean
+          description: Filter rooms by their termination status
       responses:
         "200":
           description: Successful operation


### PR DESCRIPTION
- Remove fields which are not supported anymore d76cef2
  - Such as virtual fields(https://github.com/pplink/pagecall/pull/3790), aggregated members (https://pagecall.slack.com/archives/C04JJM7APD1/p1699501733400959)
- Add support of `is_terminated` query 8500217