### PR TITLE
fix: enable property "members" when creating room

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -790,6 +790,11 @@ components:
           description:
             Determines the maximum meeting time in seconds. Once this time has elapsed, the meeting room will be automatically terminated.
             The 'meeting time' refers to the duration during which two or more participants are connected. If a `max_meeting_seconds` is set, the timer UI will display the remaining meeting time, rather than the elapsed time.
+        members:
+          type: array
+          description: Specify inviting user_id and type
+          items:
+            $ref: "#/components/schemas/RoomMember"
         webhook:
           type: object
           required:


### PR DESCRIPTION
enable property "members" when creating a room.